### PR TITLE
Add CMCONF system configuration

### DIFF
--- a/CMLibStorage.cmake
+++ b/CMLibStorage.cmake
@@ -1,3 +1,10 @@
+FIND_PACKAGE(CMLIB COMPONENTS CMCONF REQUIRED)
+
+# Adding CMCONF system
+CMCONF_INIT_SYSTEM(EXAMPLE)
+
+# Defining list of storages
 SET(STORAGE_LIST DEP)
 
+# Defining Package Tracker storage url
 SET(STORAGE_LIST_DEP "https://github.com/bacpack-system/package-tracker.git")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,9 @@ CMDEF_ADD_EXECUTABLE(
 )
 TARGET_LINK_LIBRARIES(example-project PUBLIC CURL::libcurl ZLIB::ZLIB)
 
-# Install created target
+# Install created target with all needed CMake package files
 CMDEF_INSTALL(TARGET example-project)
 
-# Install all shared library dependencies needed for json_target
+# Install all shared library dependencies needed for example-project
 # and update RUNPATH.
 BA_PACKAGE_DEPS_IMPORTED(example-project)

--- a/README.md
+++ b/README.md
@@ -5,15 +5,16 @@ documentation. It prints content of HTTP GET request for `www.example.com` domai
 
 This project [can be used as a template](#using-the-template-project) for other CMake-based projects.
 
-# Requirements 
+# Requirements
 
-No depencies are required on host system. The only `curl` dependency is pulled using Package Tracker.
+- Dependencies built and available in Package Repository. See [example usage documentation]
+- [CMCONF system] installed
 
-# Run 
+# Run
 
 ./example-projectd
 
-# Build 
+# Build
 
 ```
 mkdir -p _build && cd _build
@@ -21,17 +22,27 @@ cmake ../
 make -j 8
 ```
 
-# Using the Template Project
+# Using this Project as a template
 
-The template project can be used as a starting point for other projects. The following steps
-describe how to use it with emphasis on BacPack specific changes. More informations can be found in
+This project can be used as a starting point for other projects. The following steps describe how
+to use it with emphasis on BacPack specific changes. More informations can be found in
 [example usage documentation](https://bacpack-system.github.io/example_usage).
 
 1. (Copy the repository, update code) - not BacPack specific
-2. Update link to Package Tracker in `CMLibStorage.cmake` (sets using specific Package Repository)
-3. Update `CMakeLists.txt`:
+2. Choose in which [CMCONF] System the project will belong to.
+3. Update CMCONF system config file as stated in [config/README.md]. The config file shall not be,
+   in most cases, part of the project and shall be stored outside of the project source tree. It
+   depends on usage - if the system has the only project it could make sense to be part of the
+   project source tree.
+4. Update `CMakeLists.txt` as desired for the project needs:
     - Change `BA_PACKAGE_LIBRARY(curl v7.79.1)` to `BA_PACKAGE_LIBRARY(<your_package_name> <your_package_version>)`,
       all used Packages must be present in the used Package Repository
     - Change `FIND_PACKAGE(CURL REQUIRED)` to `FIND_PACKAGE(<your_package_name> REQUIRED)`
     - Change `TARGET_LINK_LIBRARIES(example-project PUBLIC CURL::libcurl)` to
       `TARGET_LINK_LIBRARIES(example-project PUBLIC <your_package_name>::<your_package_target>)`
+
+
+[example usage documentation]: https://bacpack-system.github.io/example_usage
+[CMCONF system]: ./config/README.md
+[config/README.md]: ./config/README.md
+[CMCONF]: https://github.com/cmakelib/cmakelib-component-cmconf

--- a/config/CMCONF_EXAMPLEConfig.cmake
+++ b/config/CMCONF_EXAMPLEConfig.cmake
@@ -24,3 +24,21 @@ CMCONF_SET(BA_PACKAGE_HTTP_AUTHORIZATION_HEADER "")
 #
 CMCONF_SET(BA_PACKAGE_URI_REVISION master)
 CMCONF_SET(BA_PACKAGE_URI_TEMPLATE_REMOTE "https://gitea.bringauto.com/fleet-protocol/package-repository/media/<REVISION>/package/<GIT_PATH>/<PACKAGE_GROUP_NAME>/<ARCHIVE_NAME>")
+
+#
+# Gitea hosted public Package Repository:
+#
+#CMCONF_SET(BA_PACKAGE_URI_TEMPLATE_REMOTE "https://gitea.example.com/username/repository/media/<REVISION>/package/<GIT_PATH>/<PACKAGE_GROUP_NAME>/<ARCHIVE_NAME>")
+
+#
+# Gitea hosted private Package Repository.
+# Do not forget to specify Access Token
+#
+#CMCONF_SET(BA_PACKAGE_HTTP_AUTHORIZATION_HEADER "token <token>")
+#CMCONF_SET(BA_PACKAGE_URI_TEMPLATE_REMOTE "https://gitea.example.com/username/repository/raw/<REVISION>/package/<GIT_PATH>/<PACKAGE_GROUP_NAME>/<ARCHIVE_NAME>")
+
+#
+# Gitlab hosted private Package Repository.
+#
+#CMCONF_SET(BA_PACKAGE_HTTP_AUTHORIZATION_HEADER "Bearer <token>")
+#CMCONF_SET(BA_PACKAGE_URI_TEMPLATE_REMOTE "https://gitlab.example.com/username/repository/-/raw/<REVISION>/package/<GIT_PATH>/<PACKAGE_GROUP_NAME>/<ARCHIVE_NAME>")

--- a/config/CMCONF_EXAMPLEConfig.cmake
+++ b/config/CMCONF_EXAMPLEConfig.cmake
@@ -1,0 +1,26 @@
+#
+# Example configuration for CMCONF system.
+#
+
+FIND_PACKAGE(CMLIB REQUIRED COMPONENTS CMCONF)
+
+CMCONF_INIT_SYSTEM(EXAMPLE)
+
+#
+# Setting using upstream Package Repository by default for this system. This can be overridden by
+# App in CMakeLists.txt.
+#
+CMCONF_SET(BA_PACKAGE_LOCAL_USE OFF)
+CMCONF_SET(BA_PACKAGE_LOCAL_PATH "")
+
+#
+# The http authorization header is usually used for accessing private Package Repositories. This
+# example does not need it, but the variable must be set.
+#
+CMCONF_SET(BA_PACKAGE_HTTP_AUTHORIZATION_HEADER "")
+
+#
+# Setting BringAuto's Package Repository URI Template
+#
+CMCONF_SET(BA_PACKAGE_URI_REVISION master)
+CMCONF_SET(BA_PACKAGE_URI_TEMPLATE_REMOTE "https://gitea.bringauto.com/fleet-protocol/package-repository/media/<REVISION>/package/<GIT_PATH>/<PACKAGE_GROUP_NAME>/<ARCHIVE_NAME>")

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,38 @@
+
+# EXAMPLE Configuration
+
+## Prerequisites
+
+- [cmakelib] installed
+- prepare Package Repository as described by [example usage documentation]
+
+## Install EXAMPLE Config
+
+The EXAMPLE config is in `CMCONF_EXAMPLEConfig.cmake` file. To install it, run following command:
+
+```bash
+cmake -DCMCONF_INSTALL_AS_SYMLINK=ON -P ./CMCONF_EXAMPLEConfig.cmake
+```
+
+To uninstall it, run following command:
+
+```bash
+cmake -DCMCONF_UNINSTALL=ON -P ./CMCONF_EXAMPLEConfig.cmake
+```
+
+## Change System Name
+
+Let `X` is a SYSTEM name.
+
+- Rename `CMCONF_EXAMPLEConfig.cmake` to `CMCONF_XConfig.cmake`,
+- Rename `EXAMPLE` to `X` in `CMCONF_XConfig.cmake`,
+- Rename `EXAMPLE` to `X` in `CMLibStorage.cmake`.
+- Install `CMCONF_XConfig.cmake` as described above.
+
+
+[CMCONF_EXAMPLEConfig.cmake]: https://github.com/bacpack-system/package-tracker/example/config
+[Package Tracker]: https://github.com/bacpack-system/package-tracker
+[Package Tracker Example]: https://github.com/bacpack-system/package-tracker/example
+[CMCONF]: https://github.com/cmakelib/cmakelib-component-cmconf
+[cmakelib]: https://github.com/cmakelib/cmakelib
+[example usage documentation]: https://bacpack-system.github.io/example_usage

--- a/config/README.md
+++ b/config/README.md
@@ -30,9 +30,5 @@ Let `X` is a SYSTEM name.
 - Install `CMCONF_XConfig.cmake` as described above.
 
 
-[CMCONF_EXAMPLEConfig.cmake]: https://github.com/bacpack-system/package-tracker/example/config
-[Package Tracker]: https://github.com/bacpack-system/package-tracker
-[Package Tracker Example]: https://github.com/bacpack-system/package-tracker/example
-[CMCONF]: https://github.com/cmakelib/cmakelib-component-cmconf
 [cmakelib]: https://github.com/cmakelib/cmakelib
 [example usage documentation]: https://bacpack-system.github.io/example_usage

--- a/config/README.md
+++ b/config/README.md
@@ -22,7 +22,7 @@ cmake -DCMCONF_UNINSTALL=ON -P ./CMCONF_EXAMPLEConfig.cmake
 
 ## Change System Name
 
-Let `X` is a SYSTEM name.
+Let `X` be the SYSTEM name.
 
 - Rename `CMCONF_EXAMPLEConfig.cmake` to `CMCONF_XConfig.cmake`,
 - Rename `EXAMPLE` to `X` in `CMCONF_XConfig.cmake`,


### PR DESCRIPTION
New cmakelib component CMCONF is in development, which should be added to Example project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an example CMCONF-based system for package configuration and initialization.
  * Adds default storage entries and a remote package-repository URI template with a default revision.
  * Disables local package usage by default while keeping HTTP auth configurable.

* **Documentation**
  * Reworked README to focus on CMCONF workflows and package-repo usage.
  * Added configuration README with install/uninstall and system-renaming guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->